### PR TITLE
Replace GSON with custom ANTLR parser and add source sections to nodes

### DIFF
--- a/language/pom.xml
+++ b/language/pom.xml
@@ -20,6 +20,19 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.antlr</groupId>
+                        <artifactId>antlr4-maven-plugin</artifactId>
+                        <version>4.7.2</version>
+                        <executions>
+                            <execution>
+                                <id>antlr</id>
+                                <goals>
+                                    <goal>antlr4</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <version>2.10</version>

--- a/language/src/main/antlr4/de/lucaswerkmeister/graaleneyj/parser/ZJson.g4
+++ b/language/src/main/antlr4/de/lucaswerkmeister/graaleneyj/parser/ZJson.g4
@@ -16,6 +16,7 @@ value returns [JsonElement element]:
 object returns [JsonObject o]:
 	BEGIN_OBJECT {
 		$o = new JsonObject();
+		$o.setStartIndex($BEGIN_OBJECT.getStartIndex());
 	}
 	(
 		firstKey=string NAME_SEPARATOR firstValue=value {
@@ -28,11 +29,14 @@ object returns [JsonObject o]:
 			}
 		)*
 	)?
-	END_OBJECT;
+	END_OBJECT {
+		$o.setStopIndex($END_OBJECT.getStopIndex());
+	};
 
 array returns [JsonArray a]:
 	BEGIN_ARRAY {
 		$a = new JsonArray();
+		$a.setStartIndex($BEGIN_ARRAY.getStartIndex());
 	}
 	(
 		firstValue=value {
@@ -45,13 +49,17 @@ array returns [JsonArray a]:
 			}
 		)*
 	)?
-	END_ARRAY;
+	END_ARRAY {
+		$a.setStopIndex($END_ARRAY.getStopIndex());
+	};
 
 stringValue returns [JsonString s]: string {
 	$s = new JsonString($string.s);
+	$s.setStartIndex($string.startIndex);
+	$s.setStopIndex($string.stopIndex);
 };
 
-string returns [String s]: STRING {
+string returns [String s, int startIndex, int stopIndex]: STRING {
 	String content = $STRING.getText();
 	int start = 1, end = content.length() - 1;
 	StringBuilder sb = new StringBuilder();
@@ -96,6 +104,8 @@ string returns [String s]: STRING {
 		}
 	}
 	$s = sb.toString();
+	$startIndex = $STRING.getStartIndex();
+	$stopIndex = $STRING.getStopIndex();
 };
 
 BEGIN_OBJECT: '{';

--- a/language/src/main/antlr4/de/lucaswerkmeister/graaleneyj/parser/ZJson.g4
+++ b/language/src/main/antlr4/de/lucaswerkmeister/graaleneyj/parser/ZJson.g4
@@ -1,0 +1,112 @@
+grammar ZJson;
+
+@parser::header {
+	import de.lucaswerkmeister.graaleneyj.parser.JsonArray;
+	import de.lucaswerkmeister.graaleneyj.parser.JsonElement;
+	import de.lucaswerkmeister.graaleneyj.parser.JsonObject;
+	import de.lucaswerkmeister.graaleneyj.parser.JsonString;
+}
+
+value returns [JsonElement element]:
+	object { $element = $object.o; } |
+	array { $element = $array.a; } |
+	stringValue { $element = $stringValue.s; };
+/* number/true/false/null not supported */
+
+object returns [JsonObject o]:
+	BEGIN_OBJECT {
+		$o = new JsonObject();
+	}
+	(
+		firstKey=string NAME_SEPARATOR firstValue=value {
+			$o.add($firstKey.s, $firstValue.element);
+		}
+		(
+			VALUE_SEPARATOR
+			otherKey=string NAME_SEPARATOR otherValue=value {
+				$o.add($otherKey.s, $otherValue.element);
+			}
+		)*
+	)?
+	END_OBJECT;
+
+array returns [JsonArray a]:
+	BEGIN_ARRAY {
+		$a = new JsonArray();
+	}
+	(
+		firstValue=value {
+			$a.add($firstValue.element);
+		}
+		(
+			VALUE_SEPARATOR
+			otherValue=value {
+				$a.add($otherValue.element);
+			}
+		)*
+	)?
+	END_ARRAY;
+
+stringValue returns [JsonString s]: string {
+	$s = new JsonString($string.s);
+};
+
+string returns [String s]: STRING {
+	String content = $STRING.getText();
+	int start = 1, end = content.length() - 1;
+	StringBuilder sb = new StringBuilder();
+	for (int i = start; i < end; i++) {
+		int codepoint = content.codePointAt(i);
+		if (codepoint == '\\') {
+			int nextCodePoint = content.codePointAt(i+1);
+			switch (nextCodePoint) {
+			case '"':
+				sb.append('"');
+				break;
+			case '\\':
+				sb.append('\\');
+				break;
+			case '/':
+				sb.append('/');
+				break;
+			case 'b':
+				sb.append('\b');
+				break;
+			case 'f':
+				sb.append('\f');
+				break;
+			case 'n':
+				sb.append('\n');
+				break;
+			case 'r':
+				sb.append('\r');
+				break;
+			case 't':
+				sb.append('\t');
+				break;
+			default:
+				throw new AssertionError("Illegal escape sequence!");
+			}
+			i++;
+		}
+		else {
+			sb.appendCodePoint(codepoint);
+			if (!Character.isBmpCodePoint(codepoint))
+				i++;
+		}
+	}
+	$s = sb.toString();
+};
+
+BEGIN_OBJECT: '{';
+END_OBJECT: '}';
+BEGIN_ARRAY: '[';
+END_ARRAY: ']';
+NAME_SEPARATOR: ':';
+VALUE_SEPARATOR: ',';
+STRING: '"' CHAR* '"';
+fragment CHAR: UNESCAPED | ESCAPED;
+fragment UNESCAPED: [\u0020-\u0021\u0023-\u005B\u005D-\u{10FFFF}];
+fragment ESCAPED: '\\' ["\\/bfnrt] | '\\u' HEX HEX HEX HEX;
+fragment HEX: [0-9a-fA-F];
+WS: [\t\n\r ]+ -> skip;

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/ZLanguage.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/ZLanguage.java
@@ -1,22 +1,13 @@
 package de.lucaswerkmeister.graaleneyj;
 
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.TokenStream;
-
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.TruffleLanguage.ContextPolicy;
 import com.oracle.truffle.api.object.Shape;
 
-import de.lucaswerkmeister.graaleneyj.nodes.ZNode;
 import de.lucaswerkmeister.graaleneyj.nodes.ZRootNode;
-import de.lucaswerkmeister.graaleneyj.parser.JsonElement;
 import de.lucaswerkmeister.graaleneyj.parser.ZCanonicalJsonParser;
-import de.lucaswerkmeister.graaleneyj.parser.ZJsonLexer;
-import de.lucaswerkmeister.graaleneyj.parser.ZJsonParser;
 import de.lucaswerkmeister.graaleneyj.runtime.ZContext;
 
 // TODO language name? context policy?
@@ -41,13 +32,7 @@ public class ZLanguage extends TruffleLanguage<ZContext> {
 			// for now
 			throw new UnsupportedOperationException("Can’t parse with arguments yet");
 		}
-		CharStream cs = CharStreams.fromReader(request.getSource().getReader());
-		ZJsonLexer lexer = new ZJsonLexer(cs);
-		TokenStream ts = new CommonTokenStream(lexer);
-		ZJsonParser jsonParser = new ZJsonParser(ts);
-		JsonElement element = jsonParser.value().element;
-		ZNode node = parser.parseJsonElement(element);
-		ZRootNode rootNode = new ZRootNode(this, node);
+		ZRootNode rootNode = parser.parseSource(request.getSource());
 		return Truffle.getRuntime().createCallTarget(rootNode);
 	}
 

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/ZLanguage.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/ZLanguage.java
@@ -1,7 +1,10 @@
 package de.lucaswerkmeister.graaleneyj;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.TokenStream;
+
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
@@ -10,7 +13,10 @@ import com.oracle.truffle.api.object.Shape;
 
 import de.lucaswerkmeister.graaleneyj.nodes.ZNode;
 import de.lucaswerkmeister.graaleneyj.nodes.ZRootNode;
+import de.lucaswerkmeister.graaleneyj.parser.JsonElement;
 import de.lucaswerkmeister.graaleneyj.parser.ZCanonicalJsonParser;
+import de.lucaswerkmeister.graaleneyj.parser.ZJsonLexer;
+import de.lucaswerkmeister.graaleneyj.parser.ZJsonParser;
 import de.lucaswerkmeister.graaleneyj.runtime.ZContext;
 
 // TODO language name? context policy?
@@ -35,7 +41,11 @@ public class ZLanguage extends TruffleLanguage<ZContext> {
 			// for now
 			throw new UnsupportedOperationException("Can’t parse with arguments yet");
 		}
-		JsonElement element = new Gson().fromJson(request.getSource().getReader(), JsonElement.class);
+		CharStream cs = CharStreams.fromReader(request.getSource().getReader());
+		ZJsonLexer lexer = new ZJsonLexer(cs);
+		TokenStream ts = new CommonTokenStream(lexer);
+		ZJsonParser jsonParser = new ZJsonParser(ts);
+		JsonElement element = jsonParser.value().element;
 		ZNode node = parser.parseJsonElement(element);
 		ZRootNode rootNode = new ZRootNode(this, node);
 		return Truffle.getRuntime().createCallTarget(rootNode);

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/nodes/ZImplementationCodeNode.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/nodes/ZImplementationCodeNode.java
@@ -55,7 +55,7 @@ public class ZImplementationCodeNode extends ZImplementationNode {
 		}
 
 		RuntimeException exception = new UnusableImplementationException("Unusable code language: " + sourceLanguage);
-		ZRootNode throwNode = new ZRootNode(zLanguage, new ZThrowConstantNode(exception));
+		ZRootNode throwNode = new ZRootNode(zLanguage, new ZThrowConstantNode(exception), getSourceSection());
 		return Truffle.getRuntime().createCallTarget(throwNode);
 	}
 

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/nodes/ZNode.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/nodes/ZNode.java
@@ -4,7 +4,10 @@ import com.oracle.truffle.api.dsl.TypeSystemReference;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
 
 import de.lucaswerkmeister.graaleneyj.runtime.ZList;
 import de.lucaswerkmeister.graaleneyj.runtime.ZObject;
@@ -12,6 +15,9 @@ import de.lucaswerkmeister.graaleneyj.runtime.ZObject;
 @TypeSystemReference(ZTypes.class)
 @NodeInfo(language = "Z language", description = "The abstract base node.") // TODO Z language? Eneyj language?
 public abstract class ZNode extends Node {
+
+	private int sourceCharIndex = -1;
+	private int sourceLength = -1;
 
 	public abstract Object execute(VirtualFrame virtualFrame);
 
@@ -33,6 +39,34 @@ public abstract class ZNode extends Node {
 
 	public ZObject executeZObject(VirtualFrame virtualFrame) throws UnexpectedResultException {
 		return ZTypesGen.expectZObject(execute(virtualFrame));
+	}
+
+	public void setSourceSection(int sourceCharIndex, int sourceLength) {
+		assert this.sourceCharIndex == -1;
+		assert this.sourceLength == -1;
+		this.sourceCharIndex = sourceCharIndex;
+		this.sourceLength = sourceLength;
+	}
+
+	public int getSourceCharIndex() {
+		return sourceCharIndex;
+	}
+
+	public int getSourceLength() {
+		return sourceLength;
+	}
+
+	@Override
+	public SourceSection getSourceSection() {
+		if (sourceCharIndex == -1) {
+			return null;
+		}
+		RootNode rootNode = getRootNode();
+		if (rootNode == null) {
+			return null;
+		}
+		Source source = rootNode.getSourceSection().getSource();
+		return source.createSection(sourceCharIndex, sourceLength);
 	}
 
 }

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/nodes/ZRootNode.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/nodes/ZRootNode.java
@@ -2,6 +2,7 @@ package de.lucaswerkmeister.graaleneyj.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.api.source.SourceSection;
 
 import de.lucaswerkmeister.graaleneyj.ZLanguage;
 
@@ -14,9 +15,12 @@ public final class ZRootNode extends RootNode {
 	@Child
 	private ZNode node;
 
-	public ZRootNode(ZLanguage language, ZNode node) {
+	private final SourceSection sourceSection;
+
+	public ZRootNode(ZLanguage language, ZNode node, SourceSection sourceSection) {
 		super(language);
 		this.node = node;
+		this.sourceSection = sourceSection;
 	}
 
 	@Override
@@ -42,6 +46,11 @@ public final class ZRootNode extends RootNode {
 	@Override
 	public Object execute(VirtualFrame virtualFrame) {
 		return node.execute(virtualFrame);
+	}
+
+	@Override
+	public SourceSection getSourceSection() {
+		return sourceSection;
 	}
 
 }

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonArray.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonArray.java
@@ -1,0 +1,22 @@
+package de.lucaswerkmeister.graaleneyj.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JsonArray extends JsonElement {
+
+	private final List<JsonElement> elements = new ArrayList<>();
+
+	public void add(JsonElement element) {
+		elements.add(element);
+	}
+
+	public int size() {
+		return elements.size();
+	}
+
+	public JsonElement get(int index) {
+		return elements.get(index);
+	}
+
+}

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonElement.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonElement.java
@@ -2,8 +2,31 @@ package de.lucaswerkmeister.graaleneyj.parser;
 
 public abstract class JsonElement {
 
+	private int sourceCharIndex = -1;
+	private int sourceLength = -1;
+
 	JsonElement() {
 		/* package-private constructor to prevent foreign subclasses */
+	}
+
+	void setStartIndex(int startIndex) {
+		assert startIndex >= 0;
+		assert sourceCharIndex == -1;
+		sourceCharIndex = startIndex;
+	}
+
+	void setStopIndex(int stopIndex) {
+		assert stopIndex > 0;
+		assert sourceLength == -1;
+		this.sourceLength = stopIndex - sourceCharIndex;
+	}
+
+	public int getSourceCharIndex() {
+		return sourceCharIndex;
+	}
+
+	public int getSourceLength() {
+		return sourceLength;
 	}
 
 	public JsonObject getAsJsonObject() {

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonElement.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonElement.java
@@ -1,0 +1,17 @@
+package de.lucaswerkmeister.graaleneyj.parser;
+
+public abstract class JsonElement {
+
+	JsonElement() {
+		/* package-private constructor to prevent foreign subclasses */
+	}
+
+	public JsonObject getAsJsonObject() {
+		throw new IllegalStateException("not an object");
+	}
+
+	public String getAsString() {
+		throw new IllegalStateException("not a string");
+	}
+
+}

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonObject.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonObject.java
@@ -1,0 +1,65 @@
+package de.lucaswerkmeister.graaleneyj.parser;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+public class JsonObject extends JsonElement {
+
+	private final Map<String, JsonElement> elements = new HashMap<>();
+
+	public void add(String key, JsonElement value) {
+		elements.put(key, value); // TODO what if key was already present?
+	}
+
+	public JsonElement get(String key) {
+		JsonElement element = elements.get(key);
+		if (element != null) {
+			return element;
+		} else {
+			throw new NoSuchElementException(key);
+		}
+	}
+
+	public JsonObject getAsJsonObject(String key) {
+		JsonElement element = elements.get(key);
+		if (element instanceof JsonObject) {
+			return (JsonObject) element;
+		} else if (element != null) {
+			throw new IllegalStateException("not an object: " + key);
+		} else {
+			throw new NoSuchElementException(key);
+		}
+	}
+
+	public JsonArray getAsJsonArray(String key) {
+		JsonElement element = elements.get(key);
+		if (element instanceof JsonArray) {
+			return (JsonArray) element;
+		} else if (element != null) {
+			throw new IllegalStateException("not an array: " + key);
+		} else {
+			throw new NoSuchElementException(key);
+		}
+	}
+
+	public int size() {
+		return elements.size();
+	}
+
+	public Set<Entry<String, JsonElement>> entrySet() {
+		return Collections.unmodifiableSet(elements.entrySet());
+	}
+
+	public Set<String> keySet() {
+		return Collections.unmodifiableSet(elements.keySet());
+	}
+
+	public JsonObject getAsJsonObject() {
+		return this;
+	}
+
+}

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonString.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/JsonString.java
@@ -1,0 +1,20 @@
+package de.lucaswerkmeister.graaleneyj.parser;
+
+public class JsonString extends JsonElement {
+
+	private final String string;
+
+	public JsonString(String string) {
+		this.string = string;
+	}
+
+	public String getString() {
+		return string;
+	}
+
+	@Override
+	public String getAsString() {
+		return string;
+	}
+
+}

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/ZCanonicalJsonParser.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/ZCanonicalJsonParser.java
@@ -4,10 +4,6 @@ import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.oracle.truffle.api.dsl.NodeFactory;
 
 import de.lucaswerkmeister.graaleneyj.ZConstants;
@@ -58,15 +54,10 @@ public class ZCanonicalJsonParser {
 		if (json instanceof JsonArray) {
 			return parseJsonArray((JsonArray) json);
 		}
-		if (json instanceof JsonPrimitive) {
-			JsonPrimitive primitive = (JsonPrimitive) json;
-			if (primitive.isString()) {
-				return parseJsonString(primitive.getAsString());
-			} else {
-				throw new IllegalArgumentException("JSON literal must be string");
-			}
+		if (json instanceof JsonString) {
+			return parseJsonString(((JsonString) json).getString());
 		}
-		throw new IllegalStateException("JSON element was neither object nor array nor primitive");
+		throw new IllegalStateException("JSON element was neither object nor array nor string");
 	}
 
 	public ZNode parseJsonObject(JsonObject json) {

--- a/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/ZCanonicalJsonParser.java
+++ b/language/src/main/java/de/lucaswerkmeister/graaleneyj/parser/ZCanonicalJsonParser.java
@@ -1,10 +1,18 @@
 package de.lucaswerkmeister.graaleneyj.parser;
 
+import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.TokenStream;
+
 import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
 
 import de.lucaswerkmeister.graaleneyj.ZConstants;
 import de.lucaswerkmeister.graaleneyj.ZLanguage;
@@ -43,8 +51,26 @@ public class ZCanonicalJsonParser {
 
 	private final ZLanguage language;
 
+	private Source currentSource;
+
 	public ZCanonicalJsonParser(ZLanguage language) {
 		this.language = language;
+	}
+
+	public ZRootNode parseSource(Source source) throws IOException {
+		assert currentSource == null;
+		currentSource = source;
+
+		CharStream cs = CharStreams.fromReader(source.getReader());
+		ZJsonLexer lexer = new ZJsonLexer(cs);
+		TokenStream ts = new CommonTokenStream(lexer);
+		ZJsonParser jsonParser = new ZJsonParser(ts);
+		JsonElement element = jsonParser.value().element;
+		ZNode node = parseJsonElement(element);
+		ZRootNode rootNode = new ZRootNode(language, node, source.createSection(0, source.getLength()));
+
+		currentSource = null;
+		return rootNode;
 	}
 
 	public ZNode parseJsonElement(JsonElement json) {
@@ -55,7 +81,7 @@ public class ZCanonicalJsonParser {
 			return parseJsonArray((JsonArray) json);
 		}
 		if (json instanceof JsonString) {
-			return parseJsonString(((JsonString) json).getString());
+			return parseJsonString((JsonString) json);
 		}
 		throw new IllegalStateException("JSON element was neither object nor array nor string");
 	}
@@ -82,7 +108,9 @@ public class ZCanonicalJsonParser {
 			members[i] = new ZObjectLiteralMemberNode(entry.getKey(), parseJsonElement(entry.getValue()));
 			i++;
 		}
-		return new ZObjectLiteralNode(members);
+		ZNode ret = new ZObjectLiteralNode(members);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	/**
@@ -100,7 +128,9 @@ public class ZCanonicalJsonParser {
 			extraMembers[i] = new ZStringLiteralMemberNode(entry.getKey(), parseJsonElement(entry.getValue()));
 			i++;
 		}
-		return new ZStringLiteralNode(json.get(ZConstants.STRING_STRING_VALUE).getAsString(), extraMembers);
+		ZNode ret = new ZStringLiteralNode(json.get(ZConstants.STRING_STRING_VALUE).getAsString(), extraMembers);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	/**
@@ -132,14 +162,18 @@ public class ZCanonicalJsonParser {
 		if (arguments.firstKey() != 1 || arguments.lastKey() != arguments.size()) {
 			throw new IllegalArgumentException("Function call keys are not contiguous: " + arguments.keySet());
 		}
+		ZNode ret;
 		if (function instanceof ZReferenceLiteralNode
 				&& ZConstants.IF.equals(((ZReferenceLiteralNode) function).getId())) {
 			if (arguments.size() != 3) {
 				throw new IllegalArgumentException("Call to if with " + arguments.size() + " ≠ 3 arguments");
 			}
-			return new ZIfNode(arguments.get(1), arguments.get(2), arguments.get(3));
+			ret = new ZIfNode(arguments.get(1), arguments.get(2), arguments.get(3));
+		} else {
+			ret = new ZFunctionCallNode(function, arguments.values().toArray(new ZNode[arguments.size()]));
 		}
-		return new ZFunctionCallNode(function, arguments.values().toArray(new ZNode[arguments.size()]));
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	public ZFunctionNode parseJsonObjectAsFunction(JsonObject json) {
@@ -155,63 +189,88 @@ public class ZCanonicalJsonParser {
 			implementationNodes[i] = parseJsonObjectAsImplementation(implementationJsons.get(i).getAsJsonObject(),
 					functionId, argumentNames);
 		}
-		return new ZFunctionNode(implementationNodes, functionId);
+		ZFunctionNode ret = new ZFunctionNode(implementationNodes, functionId);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	public ZImplementationNode parseJsonObjectAsImplementation(JsonObject json, String functionId,
 			String[] argumentNames) {
 		JsonObject implementation = json.getAsJsonObject(ZConstants.IMPLEMENTATION_IMPLEMENTATION);
 		String type = implementation.get(ZConstants.ZOBJECT_TYPE).getAsString();
+		SourceSection implementationSourceSection = currentSource.createSection(implementation.getSourceCharIndex(),
+				implementation.getSourceLength());
+		ZImplementationNode ret;
 		switch (type) {
 		case ZConstants.FUNCTIONCALL:
 			ZNode node = parseJsonObjectAsFunctionCall(implementation);
-			ZRootNode rootNode = new ZRootNode(language, node);
-			return new ZImplementationFunctioncallNode(rootNode, functionId);
+			ZRootNode rootNode = new ZRootNode(language, node, implementationSourceSection);
+			ret = new ZImplementationFunctioncallNode(rootNode, functionId);
+			break;
 		case ZConstants.BUILTIN:
 			String builtin = implementation.get(ZConstants.ZOBJECT_ID).getAsString();
 			switch (builtin) {
 			case ZConstants.IF:
 				// note: parseJsonObjectAsFunctionCall usually parses “if” calls specially, this
 				// builtin implementation is used when “if” is called indirectly
-				return makeBuiltin(ZIfNodeFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZIfNodeFactory.getInstance(), functionId, implementationSourceSection);
+				break;
 			case ZConstants.SAME:
-				return makeBuiltin(ZSameBuiltinFactory.getInstance(), functionId, ZValueBuiltinFactory.getInstance());
+				ret = makeBuiltin(ZSameBuiltinFactory.getInstance(), functionId, implementationSourceSection,
+						ZValueBuiltinFactory.getInstance());
+				break;
 			case ZConstants.VALUE:
-				return makeBuiltin(ZValueBuiltinFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZValueBuiltinFactory.getInstance(), functionId, implementationSourceSection);
+				break;
 			case ZConstants.REIFY:
-				return makeBuiltin(ZReifyBuiltinFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZReifyBuiltinFactory.getInstance(), functionId, implementationSourceSection);
+				break;
 			case ZConstants.ABSTRACT:
-				return makeBuiltin(ZAbstractBuiltinFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZAbstractBuiltinFactory.getInstance(), functionId, implementationSourceSection);
+				break;
 			case ZConstants.CHARACTERTOSTRING:
-				return makeBuiltin(ZCharacterToStringBuiltinFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZCharacterToStringBuiltinFactory.getInstance(), functionId,
+						implementationSourceSection);
+				break;
 			case ZConstants.STRINGTOCHARACTERLIST:
-				return makeBuiltin(ZStringToCharacterlistFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZStringToCharacterlistFactory.getInstance(), functionId, implementationSourceSection);
+				break;
 			case ZConstants.HEAD:
-				return makeBuiltin(ZHeadBuiltinFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZHeadBuiltinFactory.getInstance(), functionId, implementationSourceSection);
+				break;
 			case ZConstants.TAIL:
-				return makeBuiltin(ZTailBuiltinFactory.getInstance(), functionId);
+				ret = makeBuiltin(ZTailBuiltinFactory.getInstance(), functionId, implementationSourceSection);
+				break;
 			default:
-				return new ZImplementationBuiltinNode(
-						new ZRootNode(language,
-								new ZThrowConstantNode(
-										new UnusableImplementationException("Unknown builtin: " + builtin))),
-						functionId);
+				ZThrowConstantNode throwConstantNode = new ZThrowConstantNode(
+						new UnusableImplementationException("Unknown builtin: " + builtin));
+				throwConstantNode.setSourceSection(implementation.getSourceCharIndex(),
+						implementation.getSourceLength());
+				ret = new ZImplementationBuiltinNode(
+						new ZRootNode(language, throwConstantNode, implementationSourceSection), functionId);
+				break;
 			}
+			break;
 		case ZConstants.CODE:
 			String sourceLanguage = implementation.get(ZConstants.CODE_LANGUAGE).getAsString();
 			String source = implementation.get(ZConstants.CODE_SOURCE).getAsString();
-			return new ZImplementationCodeNode(language, sourceLanguage, source, functionId, argumentNames);
+			ret = new ZImplementationCodeNode(language, sourceLanguage, source, functionId, argumentNames);
+			break;
 		default:
-			return new ZImplementationBuiltinNode(
-					new ZRootNode(language,
-							new ZThrowConstantNode(
-									new UnusableImplementationException("Unsupported implementation type: " + type))),
-					functionId);
+			ZThrowConstantNode throwConstantNode = new ZThrowConstantNode(
+					new UnusableImplementationException("Unsupported implementation type: " + type));
+			throwConstantNode.setSourceSection(implementation.getSourceCharIndex(), implementation.getSourceLength());
+			ret = new ZImplementationBuiltinNode(
+					new ZRootNode(language, throwConstantNode, implementationSourceSection), functionId);
+			break;
 		}
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
-	private ZImplementationBuiltinNode makeBuiltin(NodeFactory<? extends ZNode> factory, String functionId) {
-		return makeBuiltin(factory, functionId, null);
+	private ZImplementationBuiltinNode makeBuiltin(NodeFactory<? extends ZNode> factory, String functionId,
+			SourceSection implementationSourceSection) {
+		return makeBuiltin(factory, functionId, implementationSourceSection, null);
 	}
 
 	/**
@@ -220,15 +279,17 @@ public class ZCanonicalJsonParser {
 	 *
 	 * @param factory
 	 * @param functionId
-	 * @param wrapArgumentsFactory Wrap each argument of the outer builtin with a
-	 *                             call to this builtin, which must accept a single
-	 *                             argument. Used, for instance, by the Z33/same
-	 *                             builtin to wrap each argument in a call to the
-	 *                             Z36/value builtin.
+	 * @param implementationSourceSection
+	 * @param wrapArgumentsFactory        Wrap each argument of the outer builtin
+	 *                                    with a call to this builtin, which must
+	 *                                    accept a single argument. Used, for
+	 *                                    instance, by the Z33/same builtin to wrap
+	 *                                    each argument in a call to the Z36/value
+	 *                                    builtin.
 	 * @return
 	 */
 	private ZImplementationBuiltinNode makeBuiltin(NodeFactory<? extends ZNode> factory, String functionId,
-			NodeFactory<? extends ZNode> wrapArgumentsFactory) {
+			SourceSection implementationSourceSection, NodeFactory<? extends ZNode> wrapArgumentsFactory) {
 		int argumentCount = factory.getExecutionSignature().size();
 		ZNode[] argumentNodes = new ZNode[argumentCount];
 		for (int i = 0; i < argumentCount; i++) {
@@ -241,21 +302,25 @@ public class ZCanonicalJsonParser {
 			argumentNodes[i] = argumentNode;
 		}
 		ZNode builtinNode = factory.createNode((Object) argumentNodes);
-		ZRootNode rootNode = new ZRootNode(language, builtinNode);
+		ZRootNode rootNode = new ZRootNode(language, builtinNode, implementationSourceSection);
 		return new ZImplementationBuiltinNode(rootNode, functionId);
 	}
 
 	public ZReferenceLiteralNode parseJsonObjectAsReference(JsonObject json) {
 		// TODO error handling, and check whether it’s okay to throw away all other keys
 		String id = json.get(ZConstants.REFERENCE_ID).getAsString();
-		return ZReferenceLiteralNodeGen.create(id);
+		ZReferenceLiteralNode ret = ZReferenceLiteralNodeGen.create(id);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	public ZReadArgumentNode parseJsonObjectAsArgumentReference(JsonObject json) {
 		// TODO is it safe to assume that ZwhateverKi is always the (i-1)th argument?
 		String reference = json.get(ZConstants.ARGUMENTREFERENCE_REFERENCE).getAsString();
 		int index = Integer.parseInt(reference.substring(reference.indexOf('K') + 1));
-		return new ZReadArgumentNode(index - 1);
+		ZReadArgumentNode ret = new ZReadArgumentNode(index - 1);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	public ZCharacterLiteralNode parseJsonObjectAsCharacter(JsonObject json) {
@@ -269,7 +334,10 @@ public class ZCanonicalJsonParser {
 			extraMembers[i] = new ZCharacterLiteralMemberNode(entry.getKey(), parseJsonElement(entry.getValue()));
 			i++;
 		}
-		return new ZCharacterLiteralNode(json.get(ZConstants.CHARACTER_CHARACTER).getAsString(), extraMembers);
+		ZCharacterLiteralNode ret = new ZCharacterLiteralNode(json.get(ZConstants.CHARACTER_CHARACTER).getAsString(),
+				extraMembers);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	public ZListLiteralNode parseJsonArray(JsonArray json) {
@@ -277,27 +345,31 @@ public class ZCanonicalJsonParser {
 		for (int i = 0; i < nodes.length; i++) {
 			nodes[i] = parseJsonElement(json.get(i));
 		}
-		return new ZListLiteralNode(nodes);
+		ZListLiteralNode ret = new ZListLiteralNode(nodes);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 	/**
 	 * A string represents a reference if it starts with a capital letter followed
 	 * by a digit, otherwise it represents a string literal.
 	 */
-	public ZNode parseJsonString(String json) {
-		if (json.length() < 2) {
-			return new ZStringLiteralNode(json);
+	public ZNode parseJsonString(JsonString json) {
+		String string = json.getString();
+		ZNode ret;
+		if (string.length() < 2) {
+			ret = new ZStringLiteralNode(string);
+		} else if (string.charAt(0) > 127 || string.charAt(1) > 127) {
+			ret = new ZStringLiteralNode(string);
+		} else if (!Character.isUpperCase(string.charAt(0))) {
+			ret = new ZStringLiteralNode(string);
+		} else if (!Character.isDigit(string.charAt(1))) {
+			ret = new ZStringLiteralNode(string);
+		} else {
+			ret = ZReferenceLiteralNodeGen.create(string);
 		}
-		if (json.charAt(0) > 127 || json.charAt(1) > 127) {
-			return new ZStringLiteralNode(json);
-		}
-		if (!Character.isUpperCase(json.charAt(0))) {
-			return new ZStringLiteralNode(json);
-		}
-		if (!Character.isDigit(json.charAt(1))) {
-			return new ZStringLiteralNode(json);
-		}
-		return ZReferenceLiteralNodeGen.create(json);
+		ret.setSourceSection(json.getSourceCharIndex(), json.getSourceLength());
+		return ret;
 	}
 
 }

--- a/language/src/test/java/de/lucaswerkmeister/graaleneyj/test/WikiLambdaTest.java
+++ b/language/src/test/java/de/lucaswerkmeister/graaleneyj/test/WikiLambdaTest.java
@@ -53,7 +53,7 @@ public class WikiLambdaTest {
 
 	@Test
 	public void testZTypeMembers() {
-		Value ztype = eval("Z1").execute();
+		Value ztype = eval("\"Z1\"").execute();
 		assertTrue(ztype.hasMembers());
 		Value aliases = ztype.getMember("Z2K3");
 		assertTrue(aliases.hasMembers());


### PR DESCRIPTION
This switches our JSON parser from the GSON library to a custom ANTLR-generated parser, and uses the greater insight this allows us into the JSON parse tree to attach source locations to all AST nodes. See the individual commit messages for details.